### PR TITLE
Adding CONTENT_ROOT env var

### DIFF
--- a/deconst-preparer-raml.sh
+++ b/deconst-preparer-raml.sh
@@ -10,6 +10,7 @@ exec docker run \
   -e ENVELOPE_DIR=${ENVELOPE_DIR:-} \
   -e ASSET_DIR=${ASSET_DIR:-} \
   -e VERBOSE=${VERBOSE:-} \
+  -e CONTENT_ROOT=/usr/content-repo \
   -v ${CONTENT_ROOT}:/usr/content-repo \
   deconstramlpreparer
 #  quay.io/deconst/preparer-raml ## to be used when it's all set


### PR DESCRIPTION
A co-worker and I discovered that the code will check the `CONTENT_ROOT` env var for the path it should examine for raml files. If that env var is missing, it will default to the current working directory.

In the container, this is set to `/preparer`, which was causing the code to never find the raml file we were pointing to.

Adding the `CONTENT_ROOT` to the docker command in the shell script allowed the code to find the raml file we were passing in on the command line.

Thanks!